### PR TITLE
Fix background color of resized image

### DIFF
--- a/app/Core/UploadImage.php
+++ b/app/Core/UploadImage.php
@@ -44,10 +44,10 @@ class UploadImage
             $image = new SimpleImage();
 
             $image->load($file);
-            $image->resizeInCenter(160, 160, "#ffffff");
+            $image->resizeAllInCenter(160, 160, "#ffffff");
             $image->save($path_img . $filename . '.webp', "webp");
 
-            $image->resizeInCenter(48, 48, "#ffffff");
+            $image->resizeAllInCenter(48, 48, "#ffffff");
             $image->save($path_img_small . $filename . '.webp', "webp");
 
             $new_img    = $filename . '.webp';


### PR DESCRIPTION
Issue - Если загружать изображение в формате PNG с прозрачным фоном (например изображеие аватара), то после конвертации фон изображения в формате WebP становится черным.

Причина - для конвертации изображения используется функция resizeInCenter в которую передается цвет фона, но даная функция не поддерживает установку цвета фона.

Текущее решение - используем функцию resizeAllInCenter, которая поддерживает установку цвета фона. Принудительно устанавливем цвет фона в белый для всех изображений. 

Замечание - при таком решении мы теряем возможность загружать и в дальнейшем использовать изображения с прозрачным фоном.

